### PR TITLE
ci: insert strategy matrix for github action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,10 +6,13 @@ on:
 jobs:
     check-application:
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                go: ['1.14', '1.15']
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-go@v2
               with:
-                go-version: 1.15
+                go-version: ${{matrix.go}}
             - run: cd gomath && go run math.go
             - run: cd gomath && go test


### PR DESCRIPTION
Add strategy matrix to test golang project using 1.14 and 1.15 versions