### PR TITLE
ci: add feature to push docker image to dockerhub

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,11 +33,17 @@ jobs:
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v1
 
+            - name: Login to DockerHub
+              uses: docker/login-action@v1 
+              with:
+                username: ${{ secrets.DOCKERHUB_USERNAME }}
+                password: ${{ secrets.DOCKERHUB_TOKEN }}
+
             - name: Build
               id: docker_build
               uses: docker/build-push-action@v2
               with:
                 context: ./gomath
                 file: ./gomath/Dockerfile
-                push: false
+                push: true
                 tags: talessatiro/gomath:latest


### PR DESCRIPTION
Insert new configuration to do the push of the docker golang image to the Dockerhub